### PR TITLE
Fix how findOne knows which file to return, conform to TMS

### DIFF
--- a/index.js
+++ b/index.js
@@ -516,6 +516,9 @@ module.exports = class MBTiles {
   findOne (tile) {
     return new Promise((resolve, reject) => {
       const query = 'SELECT tile_data FROM tiles WHERE tile_column=? AND tile_row=? AND zoom_level=?'
+      // Flip the Y, MBTiles are TMS
+      // https://gist.github.com/tmcw/4954720
+      tile[1] = (1 << tile[2]) - 1 - tile[1]
       this.db.get(query, tile, (error, row) => {
         if (error) {
           warning(error)

--- a/test.js
+++ b/test.js
@@ -37,6 +37,7 @@ describe('plain_1', () => {
   test('tables', () => mbtiles.tables().then(data => expect(data).toBeDefined()))
   test('findAll', () => mbtiles.findAll().then(data => expect(data).toBeDefined()))
   test('findOne', () => mbtiles.findOne([0, 0, 0]).then(data => expect(data).toBeTruthy()))
+  test('findOne - resolves correctly', () => mbtiles.findOne([15, 9, 4]).then(data => expect(data.toString().length).toBe(1139)))
   test('findOne - undefined', () => mbtiles.findOne([10, 0, 0]).then(data => expect(data).toBeUndefined()))
   test('hashes', () => mbtiles.hashes().then(index => expect(index).toBeDefined()))
   test('hash', () => expect(mbtiles.hash([0, 0, 0])).toBeDefined())


### PR DESCRIPTION
MBtiles are TMS.

Without this fix output can look like this:
![screen shot 2017-06-23 at 10 37 43 pm](https://user-images.githubusercontent.com/58878/27506107-46bd1d6e-5866-11e7-9b15-25a2ac7b1c9c.png)

And after:
![screen shot 2017-06-23 at 10 51 51 pm](https://user-images.githubusercontent.com/58878/27506116-93c38cc4-5866-11e7-97cd-d70a4a33b2c6.png)

Here's some history to the issue that I dug up:
- https://github.com/mapbox/node-mbtiles/issues/1
- https://gist.github.com/tmcw/4954720
- https://github.com/mapbox/node-mbtiles/blob/3b660439d3e71ad8c78093de943e172ae9c826b1/lib/mbtiles.js#L148-L149

@DenisCarriere - How's this look?